### PR TITLE
refactor: coreをリファクタリング

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use sdl2::{event::Event, pixels::Color};
+
 struct WindowState {
     pub width: u32,
     pub height: u32,
@@ -5,10 +7,11 @@ struct WindowState {
 
 impl WindowState {
     pub fn new(width: u32, height: u32) -> Self {
-        WindowState {
-            width: width,
-            height: height,
-        }
+        WindowState { width, height }
+    }
+
+    pub fn from_tupple((width, height): (u32, u32)) -> Self {
+        WindowState::new(width, height)
     }
 }
 
@@ -25,8 +28,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let window_size = window.size();
-    let window_state = WindowState::new(window_size.0, window_size.1);
+    let window_state = WindowState::from_tupple(window.size());
 
     let mut canvas = window.into_canvas().build().unwrap();
     let mut event_pump = sdl_context.event_pump().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,15 +34,15 @@ fn main() {
     let mut event_pump = sdl_context.event_pump().unwrap();
 
     // 初期描画
-    canvas.set_draw_color(sdl2::pixels::Color::WHITE);
+    canvas.set_draw_color(Color::WHITE);
     canvas.clear();
     canvas.present();
 
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                sdl2::event::Event::Quit { .. }
-                | sdl2::event::Event::KeyDown {
+                Event::Quit { .. }
+                | Event::KeyDown {
                     keycode: Some(sdl2::keyboard::Keycode::Escape),
                     ..
                 } => break 'running,
@@ -53,11 +53,11 @@ fn main() {
         // 描画処理
         //
         // 背景
-        canvas.set_draw_color(sdl2::pixels::Color::WHITE);
+        canvas.set_draw_color(Color::WHITE);
         canvas.clear();
 
         // キャラクター (を模した長方形)
-        canvas.set_draw_color(sdl2::pixels::Color::BLACK);
+        canvas.set_draw_color(Color::BLACK);
         canvas
             .fill_rect(sdl2::rect::Rect::new(
                 (window_state.width as i32 / 2) - (CHARACTER_WIDTH as i32 / 2),


### PR DESCRIPTION
- **refactor: WindowStateを初期化する引数にタプルを渡せるようにした**
- **refactor: `sdl2::event`と`sdl2::pixels`を省略できるようにした**
